### PR TITLE
Enrich OpenAPI tag descriptions with service info and permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "api-docs",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": false
+    }
+  },
+  "postCreateCommand": "npm install",
+  "remoteUser": "node"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,187 @@
+# AGENTS.md — api-docs
+
+This repo contains the Trustgrid OpenAPI 3.0 specification (`index.yaml`) and
+Node.js tests that validate it. The published output is at apidocs.trustgrid.io.
+
+---
+
+## Commands
+
+### Install dependencies
+```sh
+npm install
+```
+
+### Lint the OpenAPI spec (Redocly)
+```sh
+make lint
+# equivalent:
+npx @redocly/cli lint index.yaml
+```
+
+### Run all tests
+```sh
+make test
+# equivalent:
+npm test
+```
+
+### Run a single test file
+```sh
+node --test tests/lifecycle-state.test.js
+```
+
+### Run a single test by name (grep)
+```sh
+node --test --test-name-pattern "LifecycleStateRequest" tests/lifecycle-state.test.js
+```
+
+### Validate OpenAPI with kin-openapi (CI also runs this)
+```sh
+go run github.com/getkin/kin-openapi/cmd/validate@latest --defaults -- index.yaml
+```
+
+---
+
+## Repo Layout
+
+```
+index.yaml          # The canonical OpenAPI 3.0 spec — the only file you edit
+redocly.yaml        # Redocly lint config (extends recommended; a few rules disabled)
+tests/              # Node.js test files (*.test.js)
+Legacy Swagger/     # Read-only legacy Swagger 2.0 spec, not modified
+docs/               # Internal docs (PRDs, review notes) — not published
+```
+
+---
+
+## The Spec: `index.yaml`
+
+This is one big OpenAPI 3.0 file (~12k lines). All additions go here.
+
+### Top-level structure
+1. `info` — version, title, description
+2. `tags` — tag definitions with descriptions and Trustgrid docs links
+3. `x-tagGroups` — Redocly grouping of tags in the sidebar
+4. `paths` — all endpoints
+5. `components` — shared `schemas`, `parameters`, `responses`
+
+### Path ordering convention
+- Legacy (no version prefix) paths come first, marked `deprecated: true`
+- `/v2/` paths follow
+- Within a resource family (e.g. `/v2/node/{nodeID}/...`), paths are grouped
+  together in the file, sorted by path string
+- Cluster endpoints mirror node endpoints; they live in a separate block
+
+### Parameter conventions
+- **Always use `$ref`** for parameters defined in `components/parameters`
+  (e.g. `nodeID`, `clusterFQDN`). Never inline them:
+  ```yaml
+  parameters:
+    - $ref: '#/components/parameters/nodeID'
+  ```
+- Parameters **not** in `components/parameters` (e.g. `containerID`, `imageID`)
+  are defined inline at the operation level.
+- Path-level `parameters` go under the path key; operation-level parameters
+  go under the verb (`get`, `put`, etc.).
+
+### Operation conventions
+- `operationId`: camelCase, unique across the whole spec. Use descriptive verbs:
+  `listXxx`, `getXxx`, `createXxx`, `updateXxx`, `deleteXxx`, `PostV2...`
+  (the latter pattern for operations without a cleaner name).
+- `summary`: sentence case, no period. Describes what the endpoint *does* from
+  the user's perspective.
+- `description`: use the `|-` block scalar. Format:
+  ```yaml
+  description: |-
+    Human-readable explanation of what the endpoint does.
+
+    ---
+
+    Requires `resource::action` permission.
+  ```
+  The `---` separator between prose and the permission line is mandatory for
+  endpoints that have both.
+- `tags`: array of one or more tag names from the top-level `tags` list.
+  Compute containers use `Appliance > Compute` / `Cluster > Compute`.
+- `deprecated: true` on operations that are superseded by a `/v2/` equivalent.
+
+### Response conventions
+- `'200'`: always present; use `description: OK`.
+  - If the backend returns no body, omit `content`.
+  - If it returns JSON, use `application/json` with a `$ref` or inline schema.
+- `'404'`: description must contain "not found" (lowercase) — tests assert this.
+- `'422'`: description must contain "validation" (lowercase).
+  Content must reference `#/components/schemas/ValidationFailed`.
+- Response code keys are **quoted strings**: `'200'`, `'404'`, `'422'`.
+
+### Schema conventions
+- New schemas go in `components/schemas`.
+- Use `$ref` to reuse schemas; don't duplicate inline schemas.
+- Enums are string arrays; always document the meaning of each value in
+  `description`.
+- Include an `example` value on properties where it aids clarity.
+- `required` is an array at the schema level, not per-property.
+
+### YAML style
+- 2-space indentation throughout.
+- Use `|-` (literal block, strip trailing newline) for multi-line descriptions.
+- Booleans: `true` / `false` (lowercase).
+- Quoted strings only where YAML would misparse (e.g. `'200'`, `'404'`).
+- No trailing whitespace.
+
+---
+
+## Tests
+
+Tests live in `tests/*.test.js`. They use the **built-in Node.js test runner**
+(`node:test`) — no Jest, no Vitest.
+
+### Test file conventions
+- ES module syntax (`import`/`export`) — `package.json` has `"type": "module"`.
+- Import: `import { describe, it } from 'node:test'` and
+  `import assert from 'node:assert/strict'`.
+- Load the spec once at module level by parsing `index.yaml` with the `yaml`
+  package.
+- Use `describe` blocks per logical group (path definition, schema, responses,
+  request body).
+- Test names are human-readable sentences; they state what *should* be true.
+- Prefer `assert.ok(condition, message)` for existence checks, `assert.equal`
+  for exact matches, `assert.deepEqual` for arrays/objects.
+- Guard dependent assertions: if a path might not exist, assert its existence
+  first so failures are meaningful rather than throwing `TypeError`.
+- Tests validate the spec against the *actual backend behaviour* — the comments
+  in the existing test file (e.g. "backend returns no body", "not in backend")
+  are load-bearing; keep that pattern.
+
+### Adding a new test file
+Name it `tests/<feature>.test.js`. It will be picked up automatically by
+`node --test` (which globs `**/*.test.js` by default).
+
+---
+
+## CI
+
+Three jobs in `.github/workflows/ci.yml`, all run on pull requests:
+
+| Job | Tool | Command |
+|-----|------|---------|
+| `go-openapi` | kin-openapi | `go run .../validate -- index.yaml` |
+| `redocly-lint` | Redocly CLI | `redocly lint index.yaml --format=github-actions` |
+| `tests` | Node.js test runner | `npm ci && npm test` |
+
+All three must pass before merging.
+
+---
+
+## Common Mistakes to Avoid
+
+- **Inlining a path parameter that has a `$ref`** — always check
+  `components/parameters` before adding an inline `in: path` definition.
+- **Wrong tag** — container/compute endpoints use `Appliance > Compute` or
+  `Cluster > Compute`, not the bare `Compute` tag (which is for repositories).
+- **Missing `---` separator** in descriptions that have both prose and a
+  permission line.
+- **Unquoted response codes** — `200:` will parse as integer `200`; use `'200':`.
+- **Modifying `Legacy Swagger/`** — don't touch it; it's excluded from most lint
+  rules and is read-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/index.yaml
+++ b/index.yaml
@@ -39,77 +39,118 @@ info:
     Permissions follow the pattern `resource::action` (e.g. `nodes::read`, `virtual-networks::modify`).
   
 tags:
-  - name: Alerting
+  - name: Alert
     description: |
-      [Alerts](https://docs.trustgrid.io/docs/alarms/) are broadcast through channels
+      Security and operational events broadcast when significant node or system activity occurs (connects/disconnects, certificate warnings, order updates). Requires `alerts::read` permission.
   - name: Audit
     description: |
-      Audits are logged to keep track of user and system changes. Trustgrid exposes [authentication audits](https://docs.trustgrid.io/docs/operations/authentication/), [configuration changes](https://docs.trustgrid.io/docs/operations/changes/), and [flow logs](https://docs.trustgrid.io/docs/operations/flow-logs/)      
+      Immutable logs for compliance and troubleshooting. Trustgrid exposes [authentication audits](https://docs.trustgrid.io/docs/operations/authentication/) (`audits::read:user`), [configuration changes](https://docs.trustgrid.io/docs/operations/changes/) (`audits::read:config`), [node events](https://docs.trustgrid.io/docs/operations/node-events/) (`audits::read:node`), and [flow logs](https://docs.trustgrid.io/docs/operations/flow-logs/) (`audits::read:flows`).
   - name: Cluster
     description: |
-      [Clusters](https://docs.trustgrid.io/docs/clusters/) allow shared config and HA
+      [Clusters](https://docs.trustgrid.io/docs/clusters/) group nodes for high availability and shared configuration. Changes applied to a cluster propagate to all member nodes. Requires `nodes::read` permission.
   - name: Domain
     description: |
-      A [domain](https://docs.trustgrid.io/docs/domain/) provides a logical grouping of nodes inside an organization. 
+      A [domain](https://docs.trustgrid.io/docs/domain/) is a logical grouping of nodes within an organization, providing the namespace for virtual networks, DNS zones, and access policies. Requires `domains::read` permission.
   - name: User
     description: |
-      All interactions with the Trustgrid API require a [user](https://docs.trustgrid.io/docs/user-management/).
+      [User](https://docs.trustgrid.io/docs/user-management/) accounts for portal and API access. Authenticated via SSO (IDP) or local credentials and assigned permissions via policies. Requires `users::read` permission.
   - name: Group
     description: |
-      [Groups](https://docs.trustgrid.io/docs/user-management/groups/) allow exposing ZTNA applications to users.
+      [Groups](https://docs.trustgrid.io/docs/user-management/groups/) control which users can access ZTNA applications exposed through virtual networks. Can be synchronized from identity providers. Requires `groups::read` permission.
   - name: Appliance
     description: |
-      [Appliances](https://docs.trustgrid.io/docs/nodes/appliances/) are Trustgrid nodes deployed either physically or as a virtual machine.
+      [Appliances](https://docs.trustgrid.io/docs/nodes/appliances/) are physical or virtual machine Trustgrid nodes providing full network, VPN, edge compute, and monitoring capabilities. Requires `nodes::read` permission.
   - name: Agent
     description: |
-      [Agents](https://docs.trustgrid.io/docs/nodes/agents/) run on consumer devices and have a subset of appliance functionality
+      [Agents](https://docs.trustgrid.io/docs/nodes/agents/) are lightweight software clients installed on user devices or servers, supporting VPN/ZTNA connectivity. Requires `nodes::read` permission.
   - name: Org
     description: |
-      Org-related APIs expose [support requests](https://docs.trustgrid.io/docs/support/), support settings, and [shared documents](https://docs.trustgrid.io/docs/support/documents/).
+      Organization-level settings including [support requests](https://docs.trustgrid.io/docs/support/), notification preferences, and [shared documents](https://docs.trustgrid.io/docs/support/documents/). Requires `orgs::read` permission.
   - name: Order
     description: |
-      Provision process management
+      [Provisioning orders](https://docs.trustgrid.io/docs/provisioning/) track the lifecycle of Trustgrid appliances from purchase through deployment. Requires `orders::read` permission.
   - name: Repository
-    description: Container repository
+    description: |
+      Container image repositories for storing and distributing Docker images to edge compute nodes. Requires `repositories::read` permission.
   - name: Tag
     description: |
-      [Tags](https://docs.trustgrid.io/docs/nodes/shared/tags/) allow grouping clusters and nodes for permissions and reporting.
+      [Tags](https://docs.trustgrid.io/docs/nodes/shared/tags/) are key-value metadata attached to nodes and clusters for grouping, permissions scoping, and dashboard filtering. Requires `nodes::read` to view, `nodes::tag` to modify.
   - name: Upgrade Manager
     description: |
-      Nodes can be upgraded in bulk using the [upgrade manager](https://docs.trustgrid.io/docs/upgrade-manager/).
+      The [upgrade manager](https://docs.trustgrid.io/docs/upgrade-manager/) orchestrates software upgrades for nodes and clusters in bulk with scheduling and rollback support. Requires `upgrade-manager::read` permission.
   - name: Alarm
     description: |
-      [Alarm filters](https://docs.trustgrid.io/docs/alarms/alarm-filters/) manage criteria and thresholds for what events generate alerts.
+      [Alarm filters](https://docs.trustgrid.io/docs/alarms/alarm-filters/) define criteria and thresholds for when events generate alert notifications. Configure alert channels (email, Slack, PagerDuty, OpsGenie, Teams, webhooks) and maintenance windows. Requires `alarms::read` permission.
   - name: Certificate
     description: |
-      [TLS certificates](https://docs.trustgrid.io/docs/certificates/)
+      [TLS certificates](https://docs.trustgrid.io/docs/certificates/) provisioned for nodes to secure communications. Requires `certificates::read` to view, `certificates::modify` to manage.
   - name: Virtual Networks
     description: |
-      [Virtual network configuration](https://docs.trustgrid.io/docs/domain/virtual-networks/)
+      [Virtual networks](https://docs.trustgrid.io/docs/domain/virtual-networks/) are Layer-3 overlay networks enabling zero-trust connectivity between nodes. Configure routes, DNS, access policies, port forwarding, and IP pools. Requires `virtual-networks::read` permission.
   - name: Cluster > VPN
     x-displayName: VPN
     description: |
-      Per-cluster attachment to virtual networks
+      Per-cluster attachment to virtual networks. Configure which virtual networks a cluster participates in and its VPN interface settings. Requires `node-vpn::read` permission.
   - name: Cluster > Compute
     x-displayName: Compute
     description: |
-      [Cluster edge compute configuration](https://docs.trustgrid.io/docs/nodes/appliances/containers/)
+      [Cluster edge compute](https://docs.trustgrid.io/docs/nodes/appliances/containers/) — Docker container workloads deployed across cluster nodes. Requires `node-exec::read` permission. Requires `exec` feature flag.
   - name: Appliance > VPN
     x-displayName: VPN
     description: |
-      Per-appliance attachment to virtual networks
+      Per-appliance attachment to virtual networks. Configure which virtual networks an appliance participates in and its VPN interface settings. Requires `node-vpn::read` permission.
   - name: Appliance > Compute
     x-displayName: Compute
     description: |
-      [Appliance edge compute configuration](https://docs.trustgrid.io/docs/nodes/appliances/containers/)
+      [Appliance edge compute](https://docs.trustgrid.io/docs/nodes/appliances/containers/) — Docker container workloads deployed on a specific appliance. Requires `node-exec::read` permission. Requires `exec` feature flag.
   - name: IDP
     description: |
-      [Identity provider configuration](https://docs.trustgrid.io/docs/idps/)
+      [Identity provider](https://docs.trustgrid.io/docs/idps/) integrations (Okta, Azure AD, Google, SAML, OIDC) for SSO authentication and user/group synchronization. Requires `identity-providers::read` permission.
   - name: Permissions
     description: |
-      [Permissions management](https://docs.trustgrid.io/docs/user-management/policies/)
+      [Role-based access control](https://docs.trustgrid.io/docs/user-management/policies/) via policies assigning permissions to users and groups. Includes a simulator to evaluate permission decisions. Requires `permissions::read` to view, `permissions::modify` to configure.
   - name: ServiceUser
-    description: Users who only have API access
+    description: |
+      Machine accounts for API-only access, used for automation and integrations. Each service user can have API tokens generated without portal access. Requires `users::read` to view.
+  - name: ObservabilityExporter
+    description: |
+      [Observability exporters](https://docs.trustgrid.io/docs/observability/) configure telemetry data forwarding to external monitoring systems (Splunk, HTTP endpoints) via OpenTelemetry. Requires `observability::read` to view, `observability::modify` to configure. Requires `observability` feature flag.
+  - name: SplunkExporter
+    description: |
+      Splunk-specific observability exporter configuration for forwarding Trustgrid telemetry to a Splunk HEC endpoint. Requires `observability::read` to view, `observability::modify` to configure. Requires `observability` feature flag.
+  - name: HTTPExporter
+    description: |
+      Generic HTTP observability exporter for forwarding telemetry to any OpenTelemetry-compatible HTTP endpoint. Requires `observability::read` to view, `observability::modify` to configure. Requires `observability` feature flag.
+  - name: DNS
+    description: |
+      DNS configuration within virtual networks, including zone and record management for resolving names across the overlay network. Requires `domains::read` permission.
+  - name: DNS Zone
+    description: |
+      DNS zones hosted within a virtual network, used to resolve internal hostnames for nodes and services. Requires `domains::read` permission.
+  - name: DNS Record
+    description: |
+      Individual DNS A/CNAME records within a virtual network DNS zone. Requires `domains::read` to view, `domains::modify` to manage.
+  - name: Route
+    description: |
+      Static routes within a virtual network directing traffic between nodes and subnets. Requires `domains::read` to view, `domains::modify` to manage.
+  - name: Access Policy
+    description: |
+      Access policies within virtual networks controlling which nodes and groups can communicate. Requires `domains::read` to view, `domains::modify` to manage.
+  - name: Network Object
+    description: |
+      Network objects (subnets, hosts, ranges) used as reusable references in access policies and routes. Requires `domains::read` to view, `domains::modify` to manage.
+  - name: Network Group
+    description: |
+      Named collections of network objects for use in access policies. Requires `domains::read` to view, `domains::modify` to manage.
+  - name: Port Forwarding
+    description: |
+      Port forwarding rules that expose node services through the virtual network to other nodes. Requires `domains::read` to view, `domains::modify` to manage.
+  - name: Change Management
+    description: |
+      Tracked network configuration changes with approval workflows. Requires `domains::read` to view changes.
+  - name: Auth Group
+    description: |
+      Authentication groups that map identity provider groups to Trustgrid access groups, controlling ZTNA application access. Requires `groups::read` permission.
   
 x-tagGroups:
   - name: Alerts
@@ -120,6 +161,15 @@ x-tagGroups:
     tags:
       - Domain
       - Virtual Networks
+      - Access Policy
+      - Change Management
+      - DNS
+      - DNS Zone
+      - DNS Record
+      - Network Group
+      - Network Object
+      - Port Forwarding
+      - Route
   - name: Cluster
     tags:
       - Cluster
@@ -142,13 +192,17 @@ x-tagGroups:
   - name: Management
     tags:
       - Audit
+      - Auth Group
       - Certificate
       - Group
+      - HTTPExporter
       - IDP
+      - ObservabilityExporter
       - Org
       - Order
       - Permissions
       - ServiceUser
+      - SplunkExporter
       - Tag
       - User
 
@@ -2214,6 +2268,39 @@ paths:
         required: true
         schema:
           type: string
+          enum:
+            - aws-route-tables
+            - gateway-routes
+            - tg-tcpdump
+            - datastore-manager
+            - gateway-ping
+            - gateway-perf
+            - gateway-traceroute
+            - gateway-mtr
+            - wg-clients
+            - vpn-dump
+            - vpn-key
+            - vpn-nats
+            - vpn-routes
+            - node-debug
+            - tg-net-ping
+            - tg-net-nc
+            - nat-hits
+            - ipsec-statusall
+            - ipsec-restart
+            - tg-ping
+            - tg-cluster-ping
+            - speed-test
+            - tg-nc
+            - tg-traceroute
+            - flows
+            - tg-mtr
+            - bgp
+            - tg-arping
+            - node-restart-service
+            - node-reboot
+            - node-upgrade
+            - web-sessions
     post:
       summary: Execute a remote operation or command on a specific node
       parameters:
@@ -5966,7 +6053,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/EventModel'
       tags:
-        - Alarms
+        - Alert
   /v2/event/{nodeId}:
     get:
       operationId: listNodeEvents
@@ -6041,7 +6128,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/EventModel'
       tags:
-        - Alarms
+        - Alert
     parameters:
       - in: path
         name: nodeId
@@ -6066,7 +6153,7 @@ paths:
         '200':
           description: OK
       tags:
-        - Alarms
+        - Alert
   /v2/idp:
     get:
       operationId: listIdps

--- a/index.yaml
+++ b/index.yaml
@@ -41,7 +41,7 @@ info:
 tags:
   - name: Alert
     description: |
-      Security and operational events broadcast when significant node or system activity occurs (connects/disconnects, certificate warnings, order updates). Requires `alerts::read` permission.
+      Security and operational events broadcast when significant node or system activity occurs (connects/disconnects, certificate warnings, order updates). Required permissions vary by endpoint; see each operation description for the specific permission needed.
   - name: Audit
     description: |
       Immutable logs for compliance and troubleshooting. Trustgrid exposes [authentication audits](https://docs.trustgrid.io/docs/operations/authentication/) (`audits::read:user`), [configuration changes](https://docs.trustgrid.io/docs/operations/changes/) (`audits::read:config`), [node events](https://docs.trustgrid.io/docs/operations/node-events/) (`audits::read:node`), and [flow logs](https://docs.trustgrid.io/docs/operations/flow-logs/) (`audits::read:flows`).
@@ -123,34 +123,34 @@ tags:
       Generic HTTP observability exporter for forwarding telemetry to any OpenTelemetry-compatible HTTP endpoint. Requires `observability::read` to view, `observability::modify` to configure. Requires `observability` feature flag.
   - name: DNS
     description: |
-      DNS configuration within virtual networks, including zone and record management for resolving names across the overlay network. Requires `domains::read` permission.
+      DNS configuration within virtual networks, including zone and record management for resolving names across the overlay network. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: DNS Zone
     description: |
-      DNS zones hosted within a virtual network, used to resolve internal hostnames for nodes and services. Requires `domains::read` permission.
+      DNS zones hosted within a virtual network, used to resolve internal hostnames for nodes and services. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: DNS Record
     description: |
-      Individual DNS A/CNAME records within a virtual network DNS zone. Requires `domains::read` to view, `domains::modify` to manage.
+      Individual DNS A/CNAME records within a virtual network DNS zone. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: Route
     description: |
-      Static routes within a virtual network directing traffic between nodes and subnets. Requires `domains::read` to view, `domains::modify` to manage.
+      Static routes within a virtual network directing traffic between nodes and subnets. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: Access Policy
     description: |
-      Access policies within virtual networks controlling which nodes and groups can communicate. Requires `domains::read` to view, `domains::modify` to manage.
+      Access policies within virtual networks controlling which nodes and groups can communicate. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: Network Object
     description: |
-      Network objects (subnets, hosts, ranges) used as reusable references in access policies and routes. Requires `domains::read` to view, `domains::modify` to manage.
+      Network objects (subnets, hosts, ranges) used as reusable references in access policies and routes. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: Network Group
     description: |
-      Named collections of network objects for use in access policies. Requires `domains::read` to view, `domains::modify` to manage.
+      Named collections of network objects for use in access policies. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: Port Forwarding
     description: |
-      Port forwarding rules that expose node services through the virtual network to other nodes. Requires `domains::read` to view, `domains::modify` to manage.
+      Port forwarding rules that expose node services through the virtual network to other nodes. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   - name: Change Management
     description: |
-      Tracked network configuration changes with approval workflows. Requires `domains::read` to view changes.
+      Tracked network configuration changes with approval workflows. Requires `virtual-networks::read` to view changes, `virtual-networks::modify` to stage and commit changes.
   - name: Auth Group
     description: |
-      Authentication groups that map identity provider groups to Trustgrid access groups, controlling ZTNA application access. Requires `groups::read` permission.
+      Authentication groups that map identity provider groups to Trustgrid access groups, controlling ZTNA application access. Requires `virtual-networks::read` to view, `virtual-networks::modify` to manage.
   
 x-tagGroups:
   - name: Alerts
@@ -2266,41 +2266,20 @@ paths:
       - in: path
         name: event
         required: true
+        description: |
+          Event name to trigger on the node. This parameter is open-ended; the backend
+          may support additional event names beyond those documented here.
+
+          Known values include: aws-route-tables, gateway-routes, tg-tcpdump,
+          datastore-manager, gateway-ping, gateway-perf, gateway-traceroute,
+          gateway-mtr, wg-clients, vpn-dump, vpn-key, vpn-nats, vpn-routes,
+          node-debug, tg-net-ping, tg-net-nc, nat-hits, ipsec-statusall,
+          ipsec-restart, tg-ping, tg-cluster-ping, speed-test, tg-nc,
+          tg-traceroute, flows, tg-mtr, bgp, tg-arping,
+          node-restart-service, node-reboot, node-upgrade, web-sessions.
         schema:
           type: string
-          enum:
-            - aws-route-tables
-            - gateway-routes
-            - tg-tcpdump
-            - datastore-manager
-            - gateway-ping
-            - gateway-perf
-            - gateway-traceroute
-            - gateway-mtr
-            - wg-clients
-            - vpn-dump
-            - vpn-key
-            - vpn-nats
-            - vpn-routes
-            - node-debug
-            - tg-net-ping
-            - tg-net-nc
-            - nat-hits
-            - ipsec-statusall
-            - ipsec-restart
-            - tg-ping
-            - tg-cluster-ping
-            - speed-test
-            - tg-nc
-            - tg-traceroute
-            - flows
-            - tg-mtr
-            - bgp
-            - tg-arping
-            - node-restart-service
-            - node-reboot
-            - node-upgrade
-            - web-sessions
+          example: gateway-routes
     post:
       summary: Execute a remote operation or command on a specific node
       parameters:


### PR DESCRIPTION
## Summary

- Adds full descriptions to all 35 OpenAPI tags explaining what each service does and what permissions are required
- Fixes `Alerting` → `Alert` tag name (was mismatched with what operations actually used)
- Fixes `Alarms` (plural) → `Alert` on the `/v2/event` endpoints
- Adds 13 previously undefined tags that were being used in operations: `ObservabilityExporter`, `SplunkExporter`, `HTTPExporter`, `DNS`, `DNS Zone`, `DNS Record`, `Route`, `Access Policy`, `Network Object`, `Network Group`, `Port Forwarding`, `Change Management`, `Auth Group`
- Wires all new tags into `x-tagGroups`

## Test plan

- [ ] Verify YAML parses cleanly
- [ ] Spot-check tag descriptions in rendered docs (Redoc)