### PR TITLE
Improve operation descriptions for VPN, gateway, and policy endpoints

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2005,6 +2005,8 @@ paths:
       description: |-
         Update gateway configuration
 
+        Use `host` (not `ip`) for the gateway hostname.
+
         ---
 
         Requires `nodes::configure:gateway` permission.
@@ -4310,6 +4312,13 @@ paths:
           type: string
     post:
       summary: Create a VPN interface
+      description: |-
+        `inDefaultRoute` and `outDefaultRoute` are mutually exclusive — set at most one to `true`.
+
+        Inside NATs (`insideNats`) rewrite traffic arriving from the VPN before it enters the local network.
+        Outside NATs (`outsideNats`) rewrite traffic leaving the local network before it enters the VPN.
+
+        After creating or updating a VPN interface, push the cluster config for the change to take effect.
       requestBody:
         $ref: '#/components/requestBodies/VpnInterfaceUpdateModel'
       responses:
@@ -4347,6 +4356,13 @@ paths:
           type: string
     put:
       summary: Update a VPN interface
+      description: |-
+        `inDefaultRoute` and `outDefaultRoute` are mutually exclusive — set at most one to `true`.
+
+        Inside NATs (`insideNats`) rewrite traffic arriving from the VPN before it enters the local network.
+        Outside NATs (`outsideNats`) rewrite traffic leaving the local network before it enters the VPN.
+
+        After creating or updating a VPN interface, push the cluster config for the change to take effect.
       requestBody:
         $ref: '#/components/requestBodies/VpnInterfaceUpdateModel'
       responses:
@@ -7379,6 +7395,13 @@ paths:
           type: string
     post:
       summary: Create a VPN interface
+      description: |-
+        `inDefaultRoute` and `outDefaultRoute` are mutually exclusive — set at most one to `true`.
+
+        Inside NATs (`insideNats`) rewrite traffic arriving from the VPN before it enters the local network.
+        Outside NATs (`outsideNats`) rewrite traffic leaving the local network before it enters the VPN.
+
+        After creating or updating a VPN interface, push the node config for the change to take effect.
       requestBody:
         $ref: '#/components/requestBodies/VpnInterfaceUpdateModel'
       responses:
@@ -7416,6 +7439,13 @@ paths:
           type: string
     put:
       summary: Update a VPN interface
+      description: |-
+        `inDefaultRoute` and `outDefaultRoute` are mutually exclusive — set at most one to `true`.
+
+        Inside NATs (`insideNats`) rewrite traffic arriving from the VPN before it enters the local network.
+        Outside NATs (`outsideNats`) rewrite traffic leaving the local network before it enters the VPN.
+
+        After creating or updating a VPN interface, push the node config for the change to take effect.
       requestBody:
         $ref: '#/components/requestBodies/VpnInterfaceUpdateModel'
       responses:
@@ -7632,7 +7662,14 @@ paths:
         - Permissions
     post:
       summary: Create a new access control policy with specified permissions and conditions
-      description: Requires `permissions::modify` permission.
+      description: |-
+        Requires `permissions::modify` permission.
+
+        `resources` is a top-level field on the policy object, not nested inside `statements`.
+
+        Resource names use TGRN format and require the org ID: `tgrn:tg::nodes:node/{orgId}/{nodeId}`. Use `*` to match all resources of a type.
+
+        Action names use the format `{resource-type}::{action}`, e.g. `nodes::configure:apigw`. The resource type is plural.
       requestBody:
         $ref: '#/components/requestBodies/Policy'
       responses:
@@ -7686,7 +7723,14 @@ paths:
           type: string
     put:
       summary: Modify permissions and conditions for an existing access control policy
-      description: Requires `permissions::modify` permission.
+      description: |-
+        Requires `permissions::modify` permission.
+
+        `resources` is a top-level field on the policy object, not nested inside `statements`.
+
+        Resource names use TGRN format and require the org ID: `tgrn:tg::nodes:node/{orgId}/{nodeId}`. Use `*` to match all resources of a type.
+
+        Action names use the format `{resource-type}::{action}`, e.g. `nodes::configure:apigw`. The resource type is plural.
       requestBody:
         $ref: '#/components/requestBodies/Policy'
       responses:


### PR DESCRIPTION
## Summary

- `PUT /node/{nodeID}/config/gateway`: clarifies `host` field (not `ip`)
- VPN interface POST/PUT (node + cluster): documents `inDefaultRoute`/`outDefaultRoute` mutual exclusion, inside/outside NAT field semantics, and config-propagation behavior
- `POST /v2/policy` and `PUT /v2/policy/{name}`: documents `resources` top-level placement, TGRN format (requires org ID), and action name format

Human-readable versions of the same fixes applied to the MCP codemode server.