### PR TITLE
Document trigger event names and required permissions

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2212,6 +2212,12 @@ paths:
       - in: path
         name: event
         required: true
+        description: |-
+          Name of the event to trigger. Common values:
+          `node-restart-service`, `node-reboot`, `node-upgrade`, `gateway-routes`,
+          `vpn-routes`, `vpn-nats`, `tg-ping`, `tg-traceroute`, `tg-net-ping`,
+          `speed-test`, `flows`, `bgp`, `ipsec-restart`, `ipsec-statusall`.
+          Each requires either `nodes::remote-execute` or `nodes::service:{event}` permission.
         schema:
           type: string
     post:
@@ -2240,12 +2246,13 @@ paths:
 
         Add `?wait=1` to block until the node responds (useful for synchronous checks).
       parameters:
-        - description: If present, the request will return the node's event output
+        - description: Pass `1` to block until the node responds and return its output. Omit for fire-and-forget.
           in: query
           name: wait
           required: false
           schema:
-            type: string
+            type: integer
+            enum: [1]
       requestBody:
         required: false
         content:

--- a/index.yaml
+++ b/index.yaml
@@ -2216,6 +2216,28 @@ paths:
           type: string
     post:
       summary: Execute a remote operation or command on a specific node
+      description: |-
+        Sends an event to the node and optionally waits for its response.
+
+        Common `event` values:
+        - `node-restart-service` — restart the Trustgrid node service (requires `nodes::service:node-restart-service`)
+        - `node-reboot` — reboot the host OS (requires `nodes::service:node-reboot`)
+        - `node-upgrade` — upgrade node software (requires `nodes::service:node-upgrade`)
+        - `gateway-routes` — fetch current gateway routes (requires `nodes::service:gateway-routes`)
+        - `vpn-routes` — fetch virtual network routing table (requires `nodes::service:vpn-routes`)
+        - `vpn-nats` — fetch virtual network NAT table (requires `nodes::service:vpn-nats`)
+        - `tg-ping` — run a ping via the Trustgrid overlay (requires `nodes::service:tg-ping`)
+        - `tg-traceroute` — run a traceroute via the overlay (requires `nodes::service:tg-traceroute`)
+        - `tg-net-ping` — ping through the virtual network (requires `nodes::service:tg-net-ping`)
+        - `speed-test` — measure internet bandwidth (requires `nodes::service:speed-test`)
+        - `flows` — manage active network flows (requires `nodes::service:flows`)
+        - `bgp` — interact with the BGP server (requires `nodes::service:bgp`)
+        - `ipsec-restart` — restart the IPSec service (requires `nodes::service:ipsec-restart`)
+        - `ipsec-statusall` — retrieve IPSec status (requires `nodes::service:ipsec-statusall`)
+
+        All service events also accept the broad `nodes::remote-execute` permission as an alternative.
+
+        Add `?wait=1` to block until the node responds (useful for synchronous checks).
       parameters:
         - description: If present, the request will return the node's event output
           in: query


### PR DESCRIPTION
## Summary

The `POST /node/{nodeID}/trigger/{event}` endpoint accepted an opaque `event` path param with no documentation on valid values. This adds a description listing the common operational events (`node-restart-service`, `node-reboot`, `node-upgrade`) and diagnostic services (`gateway-routes`, `vpn-routes`, `tg-ping`, `flows`, `bgp`, etc.) along with the required permission for each.

Also clarifies the `?wait=1` query param behavior.