### PR TITLE
Add user policy attach/detach endpoints

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2926,6 +2926,61 @@ paths:
         required: true
         schema:
           type: string
+  /user/{email}/policy:
+    get:
+      summary: Retrieve the effective merged policy for a user
+      description: Returns the combined policy derived from all policies directly attached to the user plus those inherited via group membership.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+        - User
+    parameters:
+      - description: User email
+        in: path
+        name: email
+        required: true
+        schema:
+          type: string
+  /user/{email}/policy/{policy_id}:
+    parameters:
+      - description: User email
+        in: path
+        name: email
+        required: true
+        schema:
+          type: string
+      - description: Policy name
+        in: path
+        name: policy_id
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Attach a named policy to a user
+      description: |-
+        Adds `policy_id` to the user's set of directly attached policies.
+
+        Policies whose names start with `restricted-` cannot be attached via this endpoint.
+
+        Requires `permissions::modify` permission.
+      responses:
+        '200':
+          description: OK
+      tags:
+        - User
+    delete:
+      summary: Detach a named policy from a user
+      description: Requires `permissions::modify` permission.
+      responses:
+        '200':
+          description: OK
+      tags:
+        - User
   /user/{email}/groups:
     get:
       operationId: listUserGroups

--- a/index.yaml
+++ b/index.yaml
@@ -2936,7 +2936,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/Policy'
       tags:
         - User
     parameters:
@@ -2946,7 +2946,7 @@ paths:
         required: true
         schema:
           type: string
-  /user/{email}/policy/{policy_id}:
+  /user/{email}/policy/{name}:
     parameters:
       - description: User email
         in: path
@@ -2956,14 +2956,14 @@ paths:
           type: string
       - description: Policy name
         in: path
-        name: policy_id
+        name: name
         required: true
         schema:
           type: string
     post:
       summary: Attach a named policy to a user
       description: |-
-        Adds `policy_id` to the user's set of directly attached policies.
+        Adds `name` to the user's set of directly attached policies.
 
         Policies whose names start with `restricted-` cannot be attached via this endpoint.
 


### PR DESCRIPTION
## Summary

Documents three portal backend endpoints that were missing from the spec:

- `POST /user/{email}/policy/{policy_id}` — attach a named policy to a user
- `DELETE /user/{email}/policy/{policy_id}` — detach a policy from a user
- `GET /user/{email}/policy` — retrieve the user's effective merged policy

Includes the `restricted-` prefix guard note on attach.