### PR TITLE
Fix flow log port and timestamp fields: integer → number

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -608,7 +608,7 @@ paths:
                     sourcePort:
                       description: Source port
                       example: 1234
-                      type: integer
+                      type: number
                     sourceBytes:
                       description: Source bytes transferred
                       example: 100
@@ -624,7 +624,7 @@ paths:
                     destPort:
                       description: Destination port
                       example: 1234
-                      type: integer
+                      type: number
                     destBytes:
                       description: Destination bytes transferred
                       example: 100
@@ -3512,7 +3512,7 @@ paths:
                     sourcePort:
                       description: Source port
                       example: 1234
-                      type: integer
+                      type: number
                     sourceBytes:
                       description: Source bytes transferred
                       example: 100
@@ -3528,7 +3528,7 @@ paths:
                     destPort:
                       description: Destination port
                       example: 1234
-                      type: integer
+                      type: number
                     destBytes:
                       description: Destination bytes transferred
                       example: 100
@@ -7187,7 +7187,7 @@ paths:
                             description: >-
                               Unix timestamp in milliseconds of the start of the 1-minute interval.
                               Note: query params startDate/endDate use Unix seconds.
-                            type: integer
+                            type: number
                           node:
                             description: Friendly name of the VPN peer node being measured
                             type: string


### PR DESCRIPTION
## Summary

- `sourcePort` and `destPort` in `/audit/tail/flow_logs` and `/v2/audit/flow-logs` response schemas: `integer` → `number`
- `stats[].time` in `/v2/node/{nodeID}/plugin-logs/gateway-details`: `integer` → `number`

Some JSON clients serialize numeric values as floats (e.g. `1234.0`), which fails `type: integer` validation. `type: number` accepts both integers and floats and is more appropriate for these fields. The rest of the numeric fields in these schemas already use `number`.