### PR TITLE
Add v2 audit endpoints and deprecate legacy audit paths

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -272,7 +272,11 @@ paths:
     get:
       operationId: downloadConfigAudit
       summary: Export configuration change audit logs as a downloadable file
-      description: Requires `audits::read:config` permission.
+      deprecated: true
+      description: |-
+        This is deprecated; use `/v2/audit/changes/download` instead.
+
+        Requires `audits::read:config` permission.
       parameters:
         - description: ID for the item to audit. If specified, must include itemType.
           in: query
@@ -325,7 +329,11 @@ paths:
     get:
       operationId: downloadNodeAudit
       summary: Export node activity and operational audit logs as a downloadable file
-      description: Requires `audits::read:node` permission.
+      deprecated: true
+      description: |-
+        This is deprecated; use `/v2/audit/node/download` instead.
+
+        Requires `audits::read:node` permission.
       parameters:
         - description: Start time (unix timestamp) to query from
           in: query
@@ -346,7 +354,11 @@ paths:
     get:
       operationId: downloadUserAudit
       summary: Export user authentication and access audit logs as a downloadable file
-      description: Requires `audits::read:user` permission.
+      deprecated: true
+      description: |-
+        This is deprecated; use `/v2/audit/auth/download` instead.
+
+        Requires `audits::read:user` permission.
       responses:
         '200':
           description: OK
@@ -356,7 +368,11 @@ paths:
     get:
       operationId: tailConfigAudit
       summary: Retrieve real-time configuration change audit logs with filtering options
-      description: Requires `audits::read:config` permission.
+      deprecated: true
+      description: |-
+        This is deprecated; use `/v2/audit/changes` instead.
+
+        Requires `audits::read:config` permission.
       parameters:
         - description: ID for the item to audit. If specified, must include itemType.
           in: query
@@ -677,8 +693,9 @@ paths:
     get:
       operationId: tailNodeAudit
       summary: Retrieve real-time node operational and security audit logs
+      deprecated: true
       description: |-
-        List node (appliance or agent) audits
+        This is deprecated; use `/v2/audit/node` instead.
 
         ---
 
@@ -731,7 +748,11 @@ paths:
     get:
       operationId: tailUserAudit
       summary: Retrieve real-time user authentication and session audit logs
-      description: Requires `audits::read:user` permission.
+      deprecated: true
+      description: |-
+        This is deprecated; use `/v2/audit/auth` instead.
+
+        Requires `audits::read:user` permission.
       responses:
         '200':
           description: OK
@@ -3575,6 +3596,495 @@ paths:
                       nullable: true
                   type: object
                 type: array
+      tags:
+        - Audit
+  /v2/audit/changes:
+    get:
+      operationId: listChangeAudits
+      summary: List configuration change audit logs
+      description: |-
+        Returns paginated change audit records.
+
+        ---
+
+        Requires `audits::read:config` permission.
+      parameters:
+        - description: ISO 8601 start time
+          in: query
+          name: sTime
+          schema:
+            type: string
+        - description: ISO 8601 end time
+          in: query
+          name: eTime
+          schema:
+            type: string
+        - description: Pagination page number
+          in: query
+          name: page
+          schema:
+            type: string
+        - description: Max results per page
+          in: query
+          name: limit
+          schema:
+            type: number
+        - description: Sort like `timestamp:desc`
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Full text search
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: Filter by audit event types
+          in: query
+          name: auditTypes
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - action
+                - create
+                - update
+                - delete
+        - description: Filter by item types
+          in: query
+          name: itemTypes
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by user names
+          in: query
+          name: userNames
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by item IDs
+          in: query
+          name: itemIDs
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by IP addresses
+          in: query
+          name: ips
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          headers:
+            x-total-count:
+              description: Total number of change audit records
+              schema:
+                type: number
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChangeAuditRecord'
+      tags:
+        - Audit
+  /v2/audit/changes/download:
+    get:
+      operationId: downloadChangeAudits
+      summary: Download configuration change audit logs as CSV
+      description: |-
+        Requires `audits::read:config` permission.
+      parameters:
+        - description: ISO 8601 start time
+          in: query
+          name: sTime
+          schema:
+            type: string
+        - description: ISO 8601 end time
+          in: query
+          name: eTime
+          schema:
+            type: string
+        - description: Pagination page number
+          in: query
+          name: page
+          schema:
+            type: string
+        - description: Max results per page
+          in: query
+          name: limit
+          schema:
+            type: number
+        - description: Sort like `timestamp:desc`
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Full text search
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: Filter by audit event types
+          in: query
+          name: auditTypes
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - action
+                - create
+                - update
+                - delete
+        - description: Filter by item types
+          in: query
+          name: itemTypes
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by user names
+          in: query
+          name: userNames
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by item IDs
+          in: query
+          name: itemIDs
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by IP addresses
+          in: query
+          name: ips
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/csv:
+              schema:
+                type: string
+      tags:
+        - Audit
+  /v2/audit/node:
+    get:
+      operationId: listNodeAudits
+      summary: List node operational audit logs
+      description: |-
+        Returns paginated node audit records.
+
+        ---
+
+        Requires `audits::read:node` permission.
+      parameters:
+        - description: ISO 8601 start time
+          in: query
+          name: sTime
+          schema:
+            type: string
+        - description: ISO 8601 end time
+          in: query
+          name: eTime
+          schema:
+            type: string
+        - description: Pagination page number
+          in: query
+          name: page
+          schema:
+            type: string
+        - description: Max results per page
+          in: query
+          name: limit
+          schema:
+            type: number
+        - description: Sort like `timestamp:desc`
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Full text search
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: Filter by event categories
+          in: query
+          name: categories
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - Node Action
+                - Node Update
+                - OS Update
+        - description: Filter by node FQDNs
+          in: query
+          name: fqdns
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          headers:
+            x-total-count:
+              description: Total number of node audit records
+              schema:
+                type: number
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodeAuditRecord'
+      tags:
+        - Audit
+  /v2/audit/node/download:
+    get:
+      operationId: downloadNodeAudits
+      summary: Download node operational audit logs as CSV
+      description: |-
+        Requires `audits::read:node` permission.
+      parameters:
+        - description: ISO 8601 start time
+          in: query
+          name: sTime
+          schema:
+            type: string
+        - description: ISO 8601 end time
+          in: query
+          name: eTime
+          schema:
+            type: string
+        - description: Pagination page number
+          in: query
+          name: page
+          schema:
+            type: string
+        - description: Max results per page
+          in: query
+          name: limit
+          schema:
+            type: number
+        - description: Sort like `timestamp:desc`
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Full text search
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: Filter by event categories
+          in: query
+          name: categories
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - Node Action
+                - Node Update
+                - OS Update
+        - description: Filter by node FQDNs
+          in: query
+          name: fqdns
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/csv:
+              schema:
+                type: string
+      tags:
+        - Audit
+  /v2/audit/auth:
+    get:
+      operationId: listAuthAudits
+      summary: List user authentication audit logs
+      description: |-
+        Returns paginated auth audit records.
+
+        ---
+
+        Requires `audits::read:user` permission.
+      parameters:
+        - description: ISO 8601 start time
+          in: query
+          name: sTime
+          schema:
+            type: string
+        - description: ISO 8601 end time
+          in: query
+          name: eTime
+          schema:
+            type: string
+        - description: Pagination page number
+          in: query
+          name: page
+          schema:
+            type: string
+        - description: Max results per page
+          in: query
+          name: limit
+          schema:
+            type: number
+        - description: Sort like `timestamp:desc`
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Full text search
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: Filter by IP addresses
+          in: query
+          name: ips
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by user IDs
+          in: query
+          name: userIDs
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          headers:
+            x-total-count:
+              description: Total number of auth audit records
+              schema:
+                type: number
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuthAuditRecord'
+      tags:
+        - Audit
+  /v2/audit/auth/download:
+    get:
+      operationId: downloadAuthAudits
+      summary: Download user authentication audit logs as CSV
+      description: |-
+        Requires `audits::read:user` permission.
+      parameters:
+        - description: ISO 8601 start time
+          in: query
+          name: sTime
+          schema:
+            type: string
+        - description: ISO 8601 end time
+          in: query
+          name: eTime
+          schema:
+            type: string
+        - description: Pagination page number
+          in: query
+          name: page
+          schema:
+            type: string
+        - description: Max results per page
+          in: query
+          name: limit
+          schema:
+            type: number
+        - description: Sort like `timestamp:desc`
+          in: query
+          name: sort
+          schema:
+            type: string
+        - description: Full text search
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: Filter by IP addresses
+          in: query
+          name: ips
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - description: Filter by user IDs
+          in: query
+          name: userIDs
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/csv:
+              schema:
+                type: string
       tags:
         - Audit
   /v2/certificates:
@@ -12294,3 +12804,89 @@ components:
           type: boolean
       title: HTTPExporter
       type: object
+    ChangeAuditRecord:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Unique identifier for the audit record
+          example: 2QZBK1234567890abcdef
+        org:
+          type: string
+          description: Organization ID
+        timestamp:
+          type: string
+          description: ISO 8601 timestamp of the change
+          example: '2025-01-15T14:30:00.000Z'
+        ip:
+          type: string
+          description: IP address of the user who made the change
+          example: 192.168.1.100
+        userName:
+          type: string
+          description: Name of the user who made the change
+          example: admin@example.com
+        itemType:
+          type: string
+          description: Type of item that was changed
+          example: Node
+        itemId:
+          type: string
+          description: ID of the item that was changed
+          example: abc123
+        auditType:
+          type: string
+          description: Type of audit event
+          example: change
+        message:
+          type: string
+          description: Human-readable description of the change
+          example: Updated node configuration
+    NodeAuditRecord:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Unique identifier for the audit record
+        org:
+          type: string
+          description: Organization ID
+        timestamp:
+          type: string
+          description: ISO 8601 timestamp of the event
+        fqdn:
+          type: string
+          description: Fully qualified domain name of the node
+          example: node1.example.trustgrid.io
+        category:
+          type: string
+          description: Category of the node event
+          example: OS Update
+        value:
+          type: string
+          description: Details of the node event
+          example: OS Security Update applied
+        expires:
+          type: number
+          description: Unix epoch timestamp when this record expires
+    AuthAuditRecord:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: Unique identifier for the audit record
+        timestamp:
+          type: string
+          description: ISO 8601 timestamp of the auth event
+        ip:
+          type: string
+          description: IP address of the authentication attempt
+          example: 10.0.0.1
+        message:
+          type: string
+          description: Description of the authentication event
+          example: User logged in successfully
+        userId:
+          type: string
+          description: ID of the user who authenticated
+          example: user@example.com

--- a/index.yaml
+++ b/index.yaml
@@ -12805,6 +12805,7 @@ components:
       title: HTTPExporter
       type: object
     ChangeAuditRecord:
+      title: ChangeAuditRecord
       type: object
       properties:
         uid:
@@ -12837,12 +12838,18 @@ components:
         auditType:
           type: string
           description: Type of audit event
-          example: change
+          enum:
+            - action
+            - create
+            - update
+            - delete
+          example: update
         message:
           type: string
           description: Human-readable description of the change
           example: Updated node configuration
     NodeAuditRecord:
+      title: NodeAuditRecord
       type: object
       properties:
         uid:
@@ -12870,6 +12877,7 @@ components:
           type: number
           description: Unix epoch timestamp when this record expires
     AuthAuditRecord:
+      title: AuthAuditRecord
       type: object
       properties:
         uid:

--- a/tests/audit-v2.test.js
+++ b/tests/audit-v2.test.js
@@ -73,6 +73,7 @@ describe('/v2/audit/changes', () => {
   it('auditTypes has correct enum', () => {
     const p = findParam(getParams(pathKey), 'auditTypes');
     const enums = p?.schema?.items?.enum;
+    assert.ok(enums, 'auditTypes enum should be defined');
     assert.deepEqual([...enums].sort(), ['action', 'create', 'delete', 'update']);
   });
 
@@ -175,7 +176,9 @@ describe('/v2/audit/node', () => {
 
   it('categories has correct enum', () => {
     const p = findParam(getParams(pathKey), 'categories');
+    assert.ok(p, 'should have categories param');
     const enums = p?.schema?.items?.enum;
+    assert.ok(enums, 'categories enum should exist');
     assert.deepEqual([...enums].sort(), ['Node Action', 'Node Update', 'OS Update']);
   });
 

--- a/tests/audit-v2.test.js
+++ b/tests/audit-v2.test.js
@@ -1,0 +1,382 @@
+/**
+ * Tests for the v2 audit endpoints and their schemas
+ * Covers: changes, node, and auth audit list + download endpoints
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { parse } from 'yaml';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const specPath = join(__dirname, '..', 'index.yaml');
+const spec = parse(readFileSync(specPath, 'utf8'));
+
+// --- Helpers ---
+
+const commonQueryParams = ['sTime', 'eTime', 'page', 'limit', 'sort', 'q'];
+
+function getParams(pathKey) {
+  return spec.paths?.[pathKey]?.get?.parameters ?? [];
+}
+
+function findParam(params, name) {
+  return params.find((p) => p.name === name);
+}
+
+// --- /v2/audit/changes ---
+
+describe('/v2/audit/changes', () => {
+  const pathKey = '/v2/audit/changes';
+  const op = spec.paths?.[pathKey]?.get;
+
+  it('path exists', () => {
+    assert.ok(spec.paths?.[pathKey], `${pathKey} should exist`);
+  });
+
+  it('has correct operationId', () => {
+    assert.equal(op?.operationId, 'listChangeAudits');
+  });
+
+  it('has correct summary', () => {
+    assert.equal(op?.summary, 'List configuration change audit logs');
+  });
+
+  it('has Audit tag', () => {
+    assert.ok(op?.tags?.includes('Audit'));
+  });
+
+  it('description has --- separator and permission', () => {
+    assert.ok(op?.description?.includes('---'));
+    assert.ok(op?.description?.includes('audits::read:config'));
+  });
+
+  it('has common query parameters', () => {
+    const params = getParams(pathKey);
+    for (const name of commonQueryParams) {
+      assert.ok(findParam(params, name), `should have ${name} param`);
+    }
+  });
+
+  it('has array params with style:form explode:false', () => {
+    const params = getParams(pathKey);
+    for (const name of ['auditTypes', 'itemTypes', 'userNames', 'itemIDs', 'ips']) {
+      const p = findParam(params, name);
+      assert.ok(p, `should have ${name} param`);
+      assert.equal(p.style, 'form', `${name} style should be form`);
+      assert.equal(p.explode, false, `${name} explode should be false`);
+    }
+  });
+
+  it('auditTypes has correct enum', () => {
+    const p = findParam(getParams(pathKey), 'auditTypes');
+    const enums = p?.schema?.items?.enum;
+    assert.deepEqual([...enums].sort(), ['action', 'create', 'delete', 'update']);
+  });
+
+  it('200 response has x-total-count header', () => {
+    const header = op?.responses?.['200']?.headers?.['x-total-count'];
+    assert.ok(header, 'should have x-total-count header');
+  });
+
+  it('200 response is JSON array of ChangeAuditRecord', () => {
+    const schema = op?.responses?.['200']?.content?.['application/json']?.schema;
+    assert.equal(schema?.type, 'array');
+    assert.equal(schema?.items?.$ref, '#/components/schemas/ChangeAuditRecord');
+  });
+});
+
+// --- /v2/audit/changes/download ---
+
+describe('/v2/audit/changes/download', () => {
+  const pathKey = '/v2/audit/changes/download';
+  const op = spec.paths?.[pathKey]?.get;
+
+  it('path exists', () => {
+    assert.ok(spec.paths?.[pathKey], `${pathKey} should exist`);
+  });
+
+  it('has correct operationId', () => {
+    assert.equal(op?.operationId, 'downloadChangeAudits');
+  });
+
+  it('has Audit tag', () => {
+    assert.ok(op?.tags?.includes('Audit'));
+  });
+
+  it('has common query parameters', () => {
+    const params = getParams(pathKey);
+    for (const name of commonQueryParams) {
+      assert.ok(findParam(params, name), `should have ${name} param`);
+    }
+  });
+
+  it('has array params with style:form explode:false', () => {
+    const params = getParams(pathKey);
+    for (const name of ['auditTypes', 'itemTypes', 'userNames', 'itemIDs', 'ips']) {
+      const p = findParam(params, name);
+      assert.ok(p, `should have ${name} param`);
+      assert.equal(p.style, 'form');
+      assert.equal(p.explode, false);
+    }
+  });
+
+  it('200 response is text/csv', () => {
+    const content = op?.responses?.['200']?.content;
+    assert.ok(content?.['text/csv'], 'should have text/csv response');
+  });
+});
+
+// --- /v2/audit/node ---
+
+describe('/v2/audit/node', () => {
+  const pathKey = '/v2/audit/node';
+  const op = spec.paths?.[pathKey]?.get;
+
+  it('path exists', () => {
+    assert.ok(spec.paths?.[pathKey], `${pathKey} should exist`);
+  });
+
+  it('has correct operationId', () => {
+    assert.equal(op?.operationId, 'listNodeAudits');
+  });
+
+  it('has correct summary', () => {
+    assert.equal(op?.summary, 'List node operational audit logs');
+  });
+
+  it('has Audit tag', () => {
+    assert.ok(op?.tags?.includes('Audit'));
+  });
+
+  it('description has --- separator and permission', () => {
+    assert.ok(op?.description?.includes('---'));
+    assert.ok(op?.description?.includes('audits::read:node'));
+  });
+
+  it('has common query parameters', () => {
+    const params = getParams(pathKey);
+    for (const name of commonQueryParams) {
+      assert.ok(findParam(params, name), `should have ${name} param`);
+    }
+  });
+
+  it('has array params categories and fqdns with style:form explode:false', () => {
+    const params = getParams(pathKey);
+    for (const name of ['categories', 'fqdns']) {
+      const p = findParam(params, name);
+      assert.ok(p, `should have ${name} param`);
+      assert.equal(p.style, 'form');
+      assert.equal(p.explode, false);
+    }
+  });
+
+  it('categories has correct enum', () => {
+    const p = findParam(getParams(pathKey), 'categories');
+    const enums = p?.schema?.items?.enum;
+    assert.deepEqual([...enums].sort(), ['Node Action', 'Node Update', 'OS Update']);
+  });
+
+  it('200 response has x-total-count header', () => {
+    assert.ok(op?.responses?.['200']?.headers?.['x-total-count']);
+  });
+
+  it('200 response is JSON array of NodeAuditRecord', () => {
+    const schema = op?.responses?.['200']?.content?.['application/json']?.schema;
+    assert.equal(schema?.type, 'array');
+    assert.equal(schema?.items?.$ref, '#/components/schemas/NodeAuditRecord');
+  });
+});
+
+// --- /v2/audit/node/download ---
+
+describe('/v2/audit/node/download', () => {
+  const pathKey = '/v2/audit/node/download';
+  const op = spec.paths?.[pathKey]?.get;
+
+  it('path exists', () => {
+    assert.ok(spec.paths?.[pathKey], `${pathKey} should exist`);
+  });
+
+  it('has correct operationId', () => {
+    assert.equal(op?.operationId, 'downloadNodeAudits');
+  });
+
+  it('has Audit tag', () => {
+    assert.ok(op?.tags?.includes('Audit'));
+  });
+
+  it('has array params categories and fqdns with style:form explode:false', () => {
+    const params = getParams(pathKey);
+    for (const name of ['categories', 'fqdns']) {
+      const p = findParam(params, name);
+      assert.ok(p, `should have ${name} param`);
+      assert.equal(p.style, 'form');
+      assert.equal(p.explode, false);
+    }
+  });
+
+  it('200 response is text/csv', () => {
+    assert.ok(op?.responses?.['200']?.content?.['text/csv']);
+  });
+});
+
+// --- /v2/audit/auth ---
+
+describe('/v2/audit/auth', () => {
+  const pathKey = '/v2/audit/auth';
+  const op = spec.paths?.[pathKey]?.get;
+
+  it('path exists', () => {
+    assert.ok(spec.paths?.[pathKey], `${pathKey} should exist`);
+  });
+
+  it('has correct operationId', () => {
+    assert.equal(op?.operationId, 'listAuthAudits');
+  });
+
+  it('has correct summary', () => {
+    assert.equal(op?.summary, 'List user authentication audit logs');
+  });
+
+  it('has Audit tag', () => {
+    assert.ok(op?.tags?.includes('Audit'));
+  });
+
+  it('description has --- separator and permission', () => {
+    assert.ok(op?.description?.includes('---'));
+    assert.ok(op?.description?.includes('audits::read:user'));
+  });
+
+  it('has common query parameters', () => {
+    const params = getParams(pathKey);
+    for (const name of commonQueryParams) {
+      assert.ok(findParam(params, name), `should have ${name} param`);
+    }
+  });
+
+  it('has array params ips and userIDs with style:form explode:false', () => {
+    const params = getParams(pathKey);
+    for (const name of ['ips', 'userIDs']) {
+      const p = findParam(params, name);
+      assert.ok(p, `should have ${name} param`);
+      assert.equal(p.style, 'form');
+      assert.equal(p.explode, false);
+    }
+  });
+
+  it('200 response has x-total-count header', () => {
+    assert.ok(op?.responses?.['200']?.headers?.['x-total-count']);
+  });
+
+  it('200 response is JSON array of AuthAuditRecord', () => {
+    const schema = op?.responses?.['200']?.content?.['application/json']?.schema;
+    assert.equal(schema?.type, 'array');
+    assert.equal(schema?.items?.$ref, '#/components/schemas/AuthAuditRecord');
+  });
+});
+
+// --- /v2/audit/auth/download ---
+
+describe('/v2/audit/auth/download', () => {
+  const pathKey = '/v2/audit/auth/download';
+  const op = spec.paths?.[pathKey]?.get;
+
+  it('path exists', () => {
+    assert.ok(spec.paths?.[pathKey], `${pathKey} should exist`);
+  });
+
+  it('has correct operationId', () => {
+    assert.equal(op?.operationId, 'downloadAuthAudits');
+  });
+
+  it('has Audit tag', () => {
+    assert.ok(op?.tags?.includes('Audit'));
+  });
+
+  it('has array params ips and userIDs with style:form explode:false', () => {
+    const params = getParams(pathKey);
+    for (const name of ['ips', 'userIDs']) {
+      const p = findParam(params, name);
+      assert.ok(p, `should have ${name} param`);
+      assert.equal(p.style, 'form');
+      assert.equal(p.explode, false);
+    }
+  });
+
+  it('200 response is text/csv', () => {
+    assert.ok(op?.responses?.['200']?.content?.['text/csv']);
+  });
+});
+
+// --- Schemas ---
+
+describe('ChangeAuditRecord Schema', () => {
+  const schema = spec.components?.schemas?.ChangeAuditRecord;
+
+  it('exists', () => {
+    assert.ok(schema, 'ChangeAuditRecord schema should exist');
+  });
+
+  it('has correct properties', () => {
+    const expected = ['uid', 'org', 'timestamp', 'ip', 'userName', 'itemType', 'itemId', 'auditType', 'message'];
+    for (const prop of expected) {
+      assert.ok(schema?.properties?.[prop], `should have ${prop} property`);
+    }
+  });
+});
+
+describe('NodeAuditRecord Schema', () => {
+  const schema = spec.components?.schemas?.NodeAuditRecord;
+
+  it('exists', () => {
+    assert.ok(schema, 'NodeAuditRecord schema should exist');
+  });
+
+  it('has correct properties', () => {
+    const expected = ['uid', 'org', 'timestamp', 'fqdn', 'category', 'value', 'expires'];
+    for (const prop of expected) {
+      assert.ok(schema?.properties?.[prop], `should have ${prop} property`);
+    }
+  });
+});
+
+describe('AuthAuditRecord Schema', () => {
+  const schema = spec.components?.schemas?.AuthAuditRecord;
+
+  it('exists', () => {
+    assert.ok(schema, 'AuthAuditRecord schema should exist');
+  });
+
+  it('has correct properties', () => {
+    const expected = ['uid', 'timestamp', 'ip', 'message', 'userId'];
+    for (const prop of expected) {
+      assert.ok(schema?.properties?.[prop], `should have ${prop} property`);
+    }
+  });
+});
+
+// --- Legacy endpoints should be deprecated ---
+
+describe('Legacy audit endpoints are deprecated', () => {
+  const legacyPaths = [
+    '/audit/tail/config',
+    '/audit/download/config',
+    '/audit/tail/node',
+    '/audit/download/node',
+    '/audit/tail/user',
+    '/audit/download/user',
+  ];
+
+  for (const pathKey of legacyPaths) {
+    it(`${pathKey} is deprecated`, () => {
+      const pathDef = spec.paths?.[pathKey];
+      assert.ok(pathDef, `${pathKey} should exist`);
+      const op = pathDef.get;
+      assert.ok(op, `${pathKey} should have GET operation`);
+      assert.equal(op.deprecated, true, `${pathKey} GET should be deprecated`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Add OpenAPI definitions for 6 new v2 audit endpoints introduced in cloud PR #5821 (WOR-11772)
  - `GET /v2/audit/changes` and `/v2/audit/changes/download` (config change audits)
  - `GET /v2/audit/node` and `/v2/audit/node/download` (node operational audits)
  - `GET /v2/audit/auth` and `/v2/audit/auth/download` (user auth audits)
- Add `ChangeAuditRecord`, `NodeAuditRecord`, and `AuthAuditRecord` schemas
- Deprecate 6 legacy endpoints: `/audit/tail/config`, `/audit/download/config`, `/audit/tail/node`, `/audit/download/node`, `/audit/tail/user`, `/audit/download/user`
- Add 55 tests covering all new endpoints, schemas, and deprecations