### PR TITLE
feat: add defunct and flags filter params to getFlowLogs

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3484,6 +3484,29 @@ paths:
             type: array
             items:
               type: number
+        - description: >-
+            If provided, a flow must match at least one of the flow flags
+            provided. Decimal encoded. Known flag values: 65536 (no ACL match),
+            131072 (no rule match), 262144 (no route), 524288 (invalid TCP),
+            67108864 (TLS cert expired), 134217728 (TLS name mismatch),
+            268435456 (TLS self-signed), 536870912 (TLS mutual auth required).
+          in: query
+          name: flags
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: number
+        - description: >-
+            When true, returns only flows blocked or rejected by security
+            controls — equivalent to filtering by the union of all defunct flow
+            flags (no ACL, no rule, no route, invalid TCP, and all TLS error
+            flags). Cannot be combined with `flags`.
+          in: query
+          name: defunct
+          schema:
+            type: boolean
       responses:
         '200':
           description: OK


### PR DESCRIPTION
## Summary

- Adds `flags` array parameter to `GET /v2/audit/flow-logs` — allows filtering flows by one or more decimal-encoded flow flag values (must match at least one). This was already supported by the portal server but was undocumented.
- Adds `defunct` boolean parameter to `GET /v2/audit/flow-logs` — convenience shorthand that returns only flows blocked or rejected by security controls. Equivalent to filtering by the union of all defunct flow flags (no ACL, no rule, no route, invalid TCP, TLS cert expired, TLS name mismatch, TLS self-signed, TLS mutual auth required).

## Flag values (decimal)

| Value | Meaning |
|-------|---------|
| 65536 | No ACL match |
| 131072 | No rule match |
| 262144 | No route |
| 524288 | Invalid TCP |
| 67108864 | TLS cert expired |
| 134217728 | TLS name mismatch |
| 268435456 | TLS self-signed |
| 536870912 | TLS mutual auth required |

## Implementation note

The `flags` parameter is already handled by `cloud/portal` AuditController. The `defunct=true` shorthand requires a corresponding change to `cloud/portal` to translate it into the appropriate flags filter — that implementation PR should reference this spec change.

## Test plan

- [ ] Lint passes (`make lint`)
- [ ] `GET /v2/audit/flow-logs?defunct=true` filters for flows with any defunct flag set
- [ ] `GET /v2/audit/flow-logs?flags=65536&flags=131072` filters for flows with no-ACL or no-rule flag