### PR TITLE
docs: clarify vpn route endpoint summaries

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6149,7 +6149,7 @@ paths:
   /v2/cluster/{clusterFQDN}/vpn/{networkName}/dynamic/export-route:
     get:
       operationId: listClusterVpnExportRoutes
-      summary: Get a VPN's dynamic export routes
+      summary: Get dynamic routes exported by a cluster
       responses:
         '200':
           description: OK
@@ -6224,7 +6224,7 @@ paths:
   /v2/cluster/{clusterFQDN}/vpn/{networkName}/dynamic/import-route:
     get:
       operationId: listClusterVpnImportRoutes
-      summary: Get a VPN's dynamic import routes
+      summary: Get dynamic routes imported by a cluster
       responses:
         '200':
           description: OK
@@ -6393,7 +6393,7 @@ paths:
   /v2/cluster/{clusterFQDN}/vpn/{networkName}/route:
     get:
       operationId: listClusterVpnRoutes
-      summary: Get a VPN's routes
+      summary: Get local vpn routes for a customer
       responses:
         '200':
           description: OK
@@ -7783,7 +7783,7 @@ paths:
   /v2/domain/{domainName}/network/{networkName}/route:
     get:
       operationId: listNetworkRoutes
-      summary: List a network's routes
+      summary: Get default global vpn routes for a virtual network
       description: Requires `virtual-networks::read` permission.
       responses:
         '200':
@@ -9232,7 +9232,7 @@ paths:
   /v2/node/{nodeID}/vpn/{networkName}/dynamic/export-route:
     get:
       operationId: listNodeVpnExportRoutes
-      summary: Get a VPN's dynamic export routes
+      summary: Get dynamic routes exported by a node
       responses:
         '200':
           description: OK
@@ -9307,7 +9307,7 @@ paths:
   /v2/node/{nodeID}/vpn/{networkName}/dynamic/import-route:
     get:
       operationId: listNodeVpnImportRoutes
-      summary: Get a VPN's dynamic import routes
+      summary: Get dynamic routes imported by a node
       responses:
         '200':
           description: OK
@@ -9476,7 +9476,7 @@ paths:
   /v2/node/{nodeID}/vpn/{networkName}/route:
     get:
       operationId: listNodeVpnRoutes
-      summary: Get a VPN's routes
+      summary: Get local vpn routes for a node
       responses:
         '200':
           description: OK


### PR DESCRIPTION
## Summary

Updates `summary` fields for 7 VPN route listing endpoints per Steven Stites' requested phrasings.

| operationId | Old summary | New summary |
|---|---|---|
| `listClusterVpnRoutes` | Get a VPN's routes | Get local vpn routes for a customer |
| `listNetworkRoutes` | List a network's routes | Get default global vpn routes for a virtual network |
| `listNodeVpnRoutes` | Get a VPN's routes | Get local vpn routes for a node |
| `listClusterVpnExportRoutes` | Get a VPN's dynamic export routes | Get dynamic routes exported by a cluster |
| `listClusterVpnImportRoutes` | Get a VPN's dynamic import routes | Get dynamic routes imported by a cluster |
| `listNodeVpnExportRoutes` | Get a VPN's dynamic export routes | Get dynamic routes exported by a node |
| `listNodeVpnImportRoutes` | Get a VPN's dynamic import routes | Get dynamic routes imported by a node |

All 7 operationIds existed exactly as named. No discrepancies to flag.

> **Note:** The requester's message listed `list_cluster_vpn_export_routes` twice; the second entry was interpreted as `list_cluster_vpn_import_routes` (the import variant), which maps to `listClusterVpnImportRoutes` in the spec.

## Test plan
- [x] `make lint` passes (Redocly — no errors)
- [ ] CI jobs pass (go-openapi + tests)