### PR TITLE
fix(bgp): remove spurious peer id, document local router-id

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -12552,9 +12552,6 @@ components:
     NodeTriggerBGPPeerStatus:
       description: Runtime state of one BGP peer session
       properties:
-        id:
-          description: Peer identifier as returned by the node service
-          type: string
         connected:
           description: Whether the peer session is established
           type: boolean
@@ -12583,7 +12580,6 @@ components:
           description: Remote peer IPv4 address
           type: string
       required:
-        - id
         - connected
         - routes
         - rejections
@@ -12598,12 +12594,17 @@ components:
         router:
           type: object
           properties:
+            router:
+              description: Local BGP speaker's router-id (BGP "ID")
+              example: 10.0.0.1
+              type: string
             peers:
               description: Runtime peer session state for the local BGP speaker
               items:
                 $ref: '#/components/schemas/NodeTriggerBGPPeerStatus'
               type: array
           required:
+            - router
             - peers
         error:
           description: Error returned when runtime BGP status cannot be fetched

--- a/tests/bgp.test.js
+++ b/tests/bgp.test.js
@@ -162,4 +162,16 @@ describe("BGP trigger response schemas", () => {
       "#/components/schemas/NodeTriggerBGPPeerStatus"
     );
   });
+
+  it("documents the local BGP router-id on the runtime get response", () => {
+    const schema = spec.components.schemas.NodeTriggerBGPGetResponse;
+    assert.equal(
+      schema.properties.router.properties.router.type,
+      "string"
+    );
+    assert.ok(
+      schema.properties.router.required.includes("router"),
+      "router.router should be required"
+    );
+  });
 });


### PR DESCRIPTION
- NodeTriggerBGPPeerStatus: drop uid=1000(theath) gid=1000(theath) groups=1000(theath),4(adm),20(dialout),24(cdrom),27(sudo),30(dip),46(plugdev),116(lxd),117(docker),141(git),995(ollama) property and from ; the node never sends a per-peer id.
- NodeTriggerBGPGetResponse: add  string field to document the local BGP speaker's router-id.

Fixes #42