### PR TITLE
Fix withConfig description on GET /cluster endpoint

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -777,8 +777,8 @@ paths:
       summary: Retrieve all high-availability node clusters in the organization
       parameters:
         - description: >-
-            If specified, the nodes will return with their associated
-            configuration.
+            If specified, clusters will return with their full config
+            populated.
           in: query
           name: withConfig
           required: false


### PR DESCRIPTION
## What was done
Updated the `withConfig` query parameter description on `GET /cluster` in `index.yaml` to say: "If specified, clusters will return with their full config populated." The change was committed on `AN-458-terrbear` as `08083de` after validating with `make lint`, `npm test`, and `go run github.com/getkin/kin-openapi/cmd/validate@latest --defaults -- index.yaml`.

## Risks
None — this is a docs-only wording fix in a single spec file, and the repo validation/test suite passed cleanly.
