### PR TITLE
api-docs: remove groups param from BGP network config + update enabled param description

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -11623,7 +11623,7 @@ components:
                       prefix: 10.0.200.0/24
       properties:
         enabled:
-          description: Whether BGP is enabled on the node
+          description: Whether the BGP server is running on the node
           type: boolean
         id:
           description: Router ID for the local BGP speaker
@@ -11656,7 +11656,7 @@ components:
       description: Request body for updating the top-level BGP settings on a node
       properties:
         enabled:
-          description: Whether BGP is enabled on the node
+          description: Whether the BGP server is running on the node
           type: boolean
         id:
           description: Router ID for the local BGP speaker


### PR DESCRIPTION
## What was done
On `AN-489-terrbear`, I updated `index.yaml` in the BGP schemas only. Specifically, I changed the `enabled` property description in both `components/schemas/BGPConfig` and `components/schemas/BGPConfigUpdate` from `Whether BGP is enabled on the node` to `Whether the BGP server is running on the node`. Before changing anything, I verified that the node BGP update path `/v2/node/{nodeID}/config/network/bgp` was already wired to the narrow `BGPConfigUpdate` request body and that the existing BGP test coverage (`tests/bgp.test.js`) already enforced that `groups` is not part of that update schema, so no additional schema or test changes were needed. I then validated the result with `npm test`, `make lint`, and `go run github.com/getkin/kin-openapi/cmd/validate@latest --defaults -- index.yaml`, and committed the change as `fix(bgp): clarify enabled field description`.

## Decisions made
- Did **not** make any `groups`-related edit after inspecting the current spec and tests, because `origin/main` already had the node BGP update endpoint using `BGPConfigUpdate` and `tests/bgp.test.js` already asserted that `groups` is absent from the update schema.
- Used inferred wording `Whether the BGP server is running on the node` for `enabled` after checking the public issue body/comments, related docs, and nearby spec context, because the exact suggested sentence was not available in the visible issue comments but this wording matched the closest existing Trustgrid docs language and kept the patch minimal.
- Left tests untouched because the current suite already covered the key scope boundary (`BGPConfig` vs `BGPConfigUpdate`) and the description-only change did not justify expanding test surface.

## Risks
- The `enabled` wording was inferred from available repo and docs context rather than copied from a visible issue comment, so reviewers should confirm it matches the intended internal guidance for issue #40.
- The branch only changes schema descriptions; it does not change any rendered examples or surrounding BGP prose, so if there is another generated docs surface showing different wording elsewhere, this PR does not address it.

## Follow-on work
- None within this repo for the requested scope. Explicitly did not touch raw-config endpoint documentation, cluster-related BGP behavior, or the separate `exact`/prefix semantics mentioned in the issue thread because those would expand the change beyond this ticket.