### PR TITLE
Document sourceInterface and sourceFromClusterIP on V2 cluster service config

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -14978,6 +14978,14 @@ components:
       title: SAML Config
       type: object
     EdgeService:
+      example:
+        name: gw-http
+        protocol: tcp
+        port: 5000
+        host: 192.168.200.62
+        enabled: true
+        sourceInterface: ens192
+        sourceFromClusterIP: true
       properties:
         description:
           description: service description
@@ -15009,6 +15017,15 @@ components:
             - rdp
             - vnc
             - ssh
+          type: string
+        sourceFromClusterIP:
+          description: |-
+            When true and `sourceInterface` is set, the forwarder binds the outbound
+            socket to the cluster VIP on that interface instead of the active node's
+            interface IP. Has no effect unless `sourceInterface` is also set.
+          type: boolean
+        sourceInterface:
+          description: NIC name (e.g. `ens192`) the L4 forwarder uses to source the upstream connection. Must be set together with `sourceFromClusterIP` for cluster VIP sourcing to take effect.
           type: string
       required:
         - host

--- a/index.yaml
+++ b/index.yaml
@@ -15022,10 +15022,11 @@ components:
           description: |-
             When true and `sourceInterface` is set, the forwarder binds the outbound
             socket to the cluster VIP on that interface instead of the active node's
-            interface IP. Has no effect unless `sourceInterface` is also set.
+            interface IP. Has no effect unless `sourceInterface` is also set. Only
+            meaningful on cluster services; ignored on standalone node services.
           type: boolean
         sourceInterface:
-          description: NIC name (e.g. `ens192`) the L4 forwarder uses to source the upstream connection. Must be set together with `sourceFromClusterIP` for cluster VIP sourcing to take effect.
+          description: NIC name (e.g. `ens192`) the L4 forwarder uses to source the upstream connection. Valid on its own to control source interface binding; also required for `sourceFromClusterIP` to take effect.
           type: string
       required:
         - host


### PR DESCRIPTION
## What was done

Added two new optional fields to `components/schemas/EdgeService` in `index.yaml` — the shared schema backing the `requestBody` on four service config endpoints (POST and PUT for both cluster and node). Fields added: `sourceFromClusterIP` (boolean) and `sourceInterface` (string), placed in alphabetical order after `protocol`. Also added a schema-level `example` object showing a complete payload with both fields set. A second commit tightened the descriptions after critic review: corrected `sourceInterface` to make clear it is independently useful (not only valid when paired with `sourceFromClusterIP`), and added a note to `sourceFromClusterIP` that it is only meaningful on cluster services and is ignored on standalone node services.

## Decisions made

- **Added fields to the shared `EdgeService` schema rather than forking a cluster-specific schema.** The endpoints already share this schema; splitting it would have ballooned scope. The tradeoff is that `sourceFromClusterIP` now shows up in node endpoint docs too, which is why the description explicitly calls out the cluster-only behavior.
- **Restored `index.yaml` from a dirty working tree** rather than trying to salvage it. The file had been munged by uncommitted changes from another branch (`AN-509-terrbear`) that carried over at branch creation. Clean restore was the right call — those changes were not related to this ticket.
- **Schema-level `example` over per-property examples.** Showing the two fields in context of a complete payload communicates the intended usage more clearly than isolated per-property examples would.

## Risks

- `sourceFromClusterIP` is silently a no-op on node services. The description documents this but there is no schema-level enforcement (e.g. no `if/then` discriminator). API consumers reading the node endpoint docs will see the field and could set it expecting an effect — they get none.
- The `EdgeService` schema is also referenced by the `ServiceConfig` schema's inline `items` block (the GET response shape), which was not updated. If the backend starts returning these fields in GET responses, the response schema will be incomplete. Out of scope for this doc-only change but worth knowing.

## Follow-on work

- The `ServiceConfig` response schema (`components/schemas/ServiceConfig`) has an inline `items` object that duplicates many `EdgeService` properties. It does not include `sourceFromClusterIP` or `sourceInterface`. If the GET endpoints return these fields in the response body, that schema needs updating separately.
- Consider whether `sourceFromClusterIP` warrants a cluster-specific request schema (or an `x-cluster-only` extension annotation) rather than a prose note buried in the description.